### PR TITLE
Simplify Feature Files

### DIFF
--- a/.github/workflows/tck-test.yml
+++ b/.github/workflows/tck-test.yml
@@ -86,7 +86,8 @@ jobs:
             
             # Run behave command
             echo "Running Test: $filename"
-            behave --format json --outfile "./reports/${filename}.json" --format html --outfile "./reports/${filename}.html" "$full_path"
+            behave --define uE1=python --format json --outfile "./reports/${filename}_python.json" --format html --outfile "./reports/${filename}_python.html" "$full_path"
+            behave --define uE1=java --format json --outfile "./reports/${filename}_java.json" --format html --outfile "./reports/${filename}_java.html" "$full_path"
             echo "Finished Test: $filename"
         done
     - name: Get Behave Scripts

--- a/README.adoc
+++ b/README.adoc
@@ -37,9 +37,9 @@ $ pip install -r requirements.txt
 
 If you would like to run any tests with the Java Test Agent, follow these instructions:
 
-1. Inside a terminal/command prompt, go to up_client_socket folder (cd java).
+1. Inside a terminal/command prompt, go to up_client_socket folder (cd up_client_socket/java).
 2. Run "mvn clean install".This will install the up-client-socket-java.
-3. Go to test_agent folder and run "mvn clean install".This will generate the tck-test-agent-java JAR file under the target folder.
+3. Go to test_agent folder (cd test_agent/java) and run "mvn clean install".This will generate the tck-test-agent-java JAR file under the target folder.
 
 === Running BDD Tests
 

--- a/test_manager/README.adoc
+++ b/test_manager/README.adoc
@@ -21,8 +21,10 @@ To run these example tests:
 1. Go to the Test Manager Folder (cd test_manager)
 2. If in Windows, run "testrunner.bat".
 When prompted, enter in the feature file name (for the example, it's "register_and_send.feature").
+You will also be prompted for the language you want to test. For now, you can enter "python" or "java".
 If in Linux, run "sh testrunner.sh".
 When prompted, enter in the feature file name (for the example, it's "register_and_send.feature").
+You will also be prompted for the language you want to test. For now, you can enter "python" or "java".
 
 After running a BDD test, ensure that you close all opened command prompt windows before running a new test.
 Your report will be located in test_manager/reports.

--- a/test_manager/features/steps/tck_step_implementations.py
+++ b/test_manager/features/steps/tck_step_implementations.py
@@ -38,6 +38,8 @@ from hamcrest import assert_that, equal_to
 def create_sdk_data(context, sdk_name: str, command: str):
     context.json_dict = {}
     context.status_json = None
+    if sdk_name == "uE1":
+        sdk_name = context.config.userdata['uE1']
 
     while not context.tm.has_sdk_connection(sdk_name):
         continue

--- a/test_manager/features/tests/serializers/long_uri_deserializer.feature
+++ b/test_manager/features/tests/serializers/long_uri_deserializer.feature
@@ -26,7 +26,7 @@
 Feature: Local and Remote URI de-serialization
 
   Scenario Outline: Testing the local uri deserializer
-    Given "<uE1>" creates data for "uri_deserialize"
+    Given "uE1" creates data for "uri_deserialize"
     When sends a "uri_deserialize" request with serialized input "<serialized_uri>"
 
     Then the deserialized uri received should have the following properties:
@@ -38,29 +38,20 @@ Feature: Local and Remote URI de-serialization
       | resource.message     | <resource_message>     |
 
     Examples:
-      | uE1    | entity_name | resource_name | resource_instance | resource_message | entity_version_major | serialized_uri            |
-      | python | neelam      | rpc           | test              |                  | 0                    | /neelam//rpc.test         |
-      | python | neelam      |               |                   |                  | 0                    | /neelam                   |
-      | python | neelam      |               |                   |                  | 1                    | /neelam/1                 |
-      | python | neelam      | test          |                   |                  | 0                    | /neelam//test             |
-      | python | neelam      | test          |                   |                  | 1                    | /neelam/1/test            |
-      | python | neelam      | test          | front             |                  | 0                    | /neelam//test.front       |
-      | python | neelam      | test          | front             |                  | 1                    | /neelam/1/test.front      |
-      | python | neelam      | test          | front             | Test             | 0                    | /neelam//test.front#Test  |
-      | python | neelam      | test          | front             | Test             | 1                    | /neelam/1/test.front#Test |
-      | java   | neelam      | rpc           | test              |                  | 0                    | /neelam//rpc.test         |
-      | java   | neelam      |               |                   |                  | 0                    | /neelam                   |
-      | java   | neelam      |               |                   |                  | 1                    | /neelam/1                 |
-      | java   | neelam      | test          |                   |                  | 0                    | /neelam//test             |
-      | java   | neelam      | test          |                   |                  | 1                    | /neelam/1/test            |
-      | java   | neelam      | test          | front             |                  | 0                    | /neelam//test.front       |
-      | java   | neelam      | test          | front             |                  | 1                    | /neelam/1/test.front      |
-      | java   | neelam      | test          | front             | Test             | 0                    | /neelam//test.front#Test  |
-      | java   | neelam      | test          | front             | Test             | 1                    | /neelam/1/test.front#Test |
+      | entity_name | resource_name | resource_instance | resource_message | entity_version_major | serialized_uri            |
+      | neelam      | rpc           | test              |                  | 0                    | /neelam//rpc.test         |
+      | neelam      |               |                   |                  | 0                    | /neelam                   |
+      | neelam      |               |                   |                  | 1                    | /neelam/1                 |
+      | neelam      | test          |                   |                  | 0                    | /neelam//test             |
+      | neelam      | test          |                   |                  | 1                    | /neelam/1/test            |
+      | neelam      | test          | front             |                  | 0                    | /neelam//test.front       |
+      | neelam      | test          | front             |                  | 1                    | /neelam/1/test.front      |
+      | neelam      | test          | front             | Test             | 0                    | /neelam//test.front#Test  |
+      | neelam      | test          | front             | Test             | 1                    | /neelam/1/test.front#Test |
 
 
   Scenario Outline: Testing the remote uri deserializer
-    Given "<uE1>" creates data for "uri_deserialize"
+    Given "uE1" creates data for "uri_deserialize"
     When sends a "uri_deserialize" request with serialized input "<serialized_uri>"
     Then the deserialized uri received should have the following properties:
       | Field                | Value                  |
@@ -72,22 +63,13 @@ Feature: Local and Remote URI de-serialization
       | resource.message     | <resource_message>     |
 
     Examples:
-      | uE1    | authority_name | entity_name | resource_name | resource_instance | resource_message | entity_version_major | serialized_uri                              |
-      | python | vcu.my_car_vin | neelam      |               |                   |                  | 0                    | //vcu.my_car_vin/neelam                   |
-      | python | vcu.my_car_vin | neelam      |               |                   |                  | 1                    | //vcu.my_car_vin/neelam/1                 |
-      | python | vcu.my_car_vin | neelam      | test          |                   |                  | 1                    | //vcu.my_car_vin/neelam/1/test            |
-      | python | vcu.my_car_vin | neelam      | test          |                   |                  | 0                    | //vcu.my_car_vin/neelam//test             |
-      | python | vcu.my_car_vin | neelam      | test          | front             |                  | 1                    | //vcu.my_car_vin/neelam/1/test.front      |
-      | python | vcu.my_car_vin | neelam      | test          | front             |                  | 0                    | //vcu.my_car_vin/neelam//test.front       |
-      | python | vcu.my_car_vin | neelam      | test          | front             | Test             | 1                    | //vcu.my_car_vin/neelam/1/test.front#Test |
-      | python | vcu.my_car_vin | neelam      | test          | front             | Test             | 0                    | //vcu.my_car_vin/neelam//test.front#Test  |
-      | python | vcu.my_car_vin | petapp      | rpc           | response          |                  | 0                    | //vcu.my_car_vin/petapp//rpc.response     |
-      | java   | vcu.my_car_vin | neelam      |               |                   |                  | 0                    | //vcu.my_car_vin/neelam                   |
-      | java   | vcu.my_car_vin | neelam      |               |                   |                  | 1                    | //vcu.my_car_vin/neelam/1                 |
-      | java   | vcu.my_car_vin | neelam      | test          |                   |                  | 1                    | //vcu.my_car_vin/neelam/1/test            |
-      | java   | vcu.my_car_vin | neelam      | test          |                   |                  | 0                    | //vcu.my_car_vin/neelam//test             |
-      | java   | vcu.my_car_vin | neelam      | test          | front             |                  | 1                    | //vcu.my_car_vin/neelam/1/test.front      |
-      | java   | vcu.my_car_vin | neelam      | test          | front             |                  | 0                    | //vcu.my_car_vin/neelam//test.front       |
-      | java   | vcu.my_car_vin | neelam      | test          | front             | Test             | 1                    | //vcu.my_car_vin/neelam/1/test.front#Test |
-      | java   | vcu.my_car_vin | neelam      | test          | front             | Test             | 0                    | //vcu.my_car_vin/neelam//test.front#Test  |
-      | java   | vcu.my_car_vin | petapp      | rpc           | response          |                  | 0                    | //vcu.my_car_vin/petapp//rpc.response     |
+      | authority_name | entity_name | resource_name | resource_instance | resource_message | entity_version_major | serialized_uri                            |
+      | vcu.my_car_vin | neelam      |               |                   |                  | 0                    | //vcu.my_car_vin/neelam                   |
+      | vcu.my_car_vin | neelam      |               |                   |                  | 1                    | //vcu.my_car_vin/neelam/1                 |
+      | vcu.my_car_vin | neelam      | test          |                   |                  | 1                    | //vcu.my_car_vin/neelam/1/test            |
+      | vcu.my_car_vin | neelam      | test          |                   |                  | 0                    | //vcu.my_car_vin/neelam//test             |
+      | vcu.my_car_vin | neelam      | test          | front             |                  | 1                    | //vcu.my_car_vin/neelam/1/test.front      |
+      | vcu.my_car_vin | neelam      | test          | front             |                  | 0                    | //vcu.my_car_vin/neelam//test.front       |
+      | vcu.my_car_vin | neelam      | test          | front             | Test             | 1                    | //vcu.my_car_vin/neelam/1/test.front#Test |
+      | vcu.my_car_vin | neelam      | test          | front             | Test             | 0                    | //vcu.my_car_vin/neelam//test.front#Test  |
+      | vcu.my_car_vin | petapp      | rpc           | response          |                  | 0                    | //vcu.my_car_vin/petapp//rpc.response     |

--- a/test_manager/features/tests/serializers/long_uri_serializer.feature
+++ b/test_manager/features/tests/serializers/long_uri_serializer.feature
@@ -26,7 +26,7 @@
 Feature: Local and Remote URI serialization
 
   Scenario Outline: Testing the local uri serializer
-    Given "<uE1>" creates data for "uri_serialize"
+    Given "uE1" creates data for "uri_serialize"
     And sets "entity.name" to "<entity_name>"
     And sets "entity.version_major" to "<entity_version_major>"
     And sets "resource.name" to "<resource_name>"
@@ -37,28 +37,19 @@ Feature: Local and Remote URI serialization
     Then the serialized uri received is "<expected_uri>"
 
     Examples:
-      | uE1    | entity_name | resource_name | resource_instance | resource_message | entity_version_major | expected_uri              |
-      | python | neelam      | rpc           | test              |                  | 0                    | /neelam//rpc.test         |
-      | python | neelam      |               |                   |                  | 0                    | /neelam                   |
-      | python | neelam      |               |                   |                  | 1                    | /neelam/1                 |
-      | python | neelam      | test          |                   |                  | 0                    | /neelam//test             |
-      | python | neelam      | test          |                   |                  | 1                    | /neelam/1/test            |
-      | python | neelam      | test          | front             |                  | 0                    | /neelam//test.front       |
-      | python | neelam      | test          | front             |                  | 1                    | /neelam/1/test.front      |
-      | python | neelam      | test          | front             | Test             | 0                    | /neelam//test.front#Test  |
-      | python | neelam      | test          | front             | Test             | 1                    | /neelam/1/test.front#Test |
-      | java   | neelam      | rpc           | test              |                  | 0                    | /neelam//rpc.test         |
-      | java   | neelam      |               |                   |                  | 0                    | /neelam                   |
-      | java   | neelam      |               |                   |                  | 1                    | /neelam/1                 |
-      | java   | neelam      | test          |                   |                  | 0                    | /neelam//test             |
-      | java   | neelam      | test          |                   |                  | 1                    | /neelam/1/test            |
-      | java   | neelam      | test          | front             |                  | 0                    | /neelam//test.front       |
-      | java   | neelam      | test          | front             |                  | 1                    | /neelam/1/test.front      |
-      | java   | neelam      | test          | front             | Test             | 0                    | /neelam//test.front#Test  |
-      | java   | neelam      | test          | front             | Test             | 1                    | /neelam/1/test.front#Test |
+      | entity_name | resource_name | resource_instance | resource_message | entity_version_major | expected_uri              |
+      | neelam      | rpc           | test              |                  | 0                    | /neelam//rpc.test         |
+      | neelam      |               |                   |                  | 0                    | /neelam                   |
+      | neelam      |               |                   |                  | 1                    | /neelam/1                 |
+      | neelam      | test          |                   |                  | 0                    | /neelam//test             |
+      | neelam      | test          |                   |                  | 1                    | /neelam/1/test            |
+      | neelam      | test          | front             |                  | 0                    | /neelam//test.front       |
+      | neelam      | test          | front             |                  | 1                    | /neelam/1/test.front      |
+      | neelam      | test          | front             | Test             | 0                    | /neelam//test.front#Test  |
+      | neelam      | test          | front             | Test             | 1                    | /neelam/1/test.front#Test |
 
   Scenario Outline: Testing the remote uri serializer
-    Given "<uE1>" creates data for "uri_serialize"
+    Given "uE1" creates data for "uri_serialize"
     And sets "authority.name" to "<authority_name>"
     And sets "entity.name" to "<entity_name>"
     And sets "entity.version_major" to "<entity_version_major>"
@@ -70,22 +61,13 @@ Feature: Local and Remote URI serialization
     Then the serialized uri received is "<expected_uri>"
     
     Examples:
-      | uE1    | authority_name | entity_name | resource_name | resource_instance | resource_message | entity_version_major | expected_uri                              |
-      | python | vcu.my_car_vin | neelam      |               |                   |                  | 0                    | //vcu.my_car_vin/neelam                   |
-      | python | vcu.my_car_vin | neelam      |               |                   |                  | 1                    | //vcu.my_car_vin/neelam/1                 |
-      | python | vcu.my_car_vin | neelam      | test          |                   |                  | 1                    | //vcu.my_car_vin/neelam/1/test            |
-      | python | vcu.my_car_vin | neelam      | test          |                   |                  | 0                    | //vcu.my_car_vin/neelam//test             |
-      | python | vcu.my_car_vin | neelam      | test          | front             |                  | 1                    | //vcu.my_car_vin/neelam/1/test.front      |
-      | python | vcu.my_car_vin | neelam      | test          | front             |                  | 0                    | //vcu.my_car_vin/neelam//test.front       |
-      | python | vcu.my_car_vin | neelam      | test          | front             | Test             | 1                    | //vcu.my_car_vin/neelam/1/test.front#Test |
-      | python | vcu.my_car_vin | neelam      | test          | front             | Test             | 0                    | //vcu.my_car_vin/neelam//test.front#Test  |
-      | python | vcu.my_car_vin | petapp      | rpc           | response          |                  | 0                    | //vcu.my_car_vin/petapp//rpc.response     |
-      | java   | vcu.my_car_vin | neelam      |               |                   |                  | 0                    | //vcu.my_car_vin/neelam                   |
-      | java   | vcu.my_car_vin | neelam      |               |                   |                  | 1                    | //vcu.my_car_vin/neelam/1                 |
-      | java   | vcu.my_car_vin | neelam      | test          |                   |                  | 1                    | //vcu.my_car_vin/neelam/1/test            |
-      | java   | vcu.my_car_vin | neelam      | test          |                   |                  | 0                    | //vcu.my_car_vin/neelam//test             |
-      | java   | vcu.my_car_vin | neelam      | test          | front             |                  | 1                    | //vcu.my_car_vin/neelam/1/test.front      |
-      | java   | vcu.my_car_vin | neelam      | test          | front             |                  | 0                    | //vcu.my_car_vin/neelam//test.front       |
-      | java   | vcu.my_car_vin | neelam      | test          | front             | Test             | 1                    | //vcu.my_car_vin/neelam/1/test.front#Test |
-      | java   | vcu.my_car_vin | neelam      | test          | front             | Test             | 0                    | //vcu.my_car_vin/neelam//test.front#Test  |
-      | java   | vcu.my_car_vin | petapp      | rpc           | response          |                  | 0                    | //vcu.my_car_vin/petapp//rpc.response     |
+      | authority_name | entity_name | resource_name | resource_instance | resource_message | entity_version_major | expected_uri                              |
+      | vcu.my_car_vin | neelam      |               |                   |                  | 0                    | //vcu.my_car_vin/neelam                   |
+      | vcu.my_car_vin | neelam      |               |                   |                  | 1                    | //vcu.my_car_vin/neelam/1                 |
+      | vcu.my_car_vin | neelam      | test          |                   |                  | 1                    | //vcu.my_car_vin/neelam/1/test            |
+      | vcu.my_car_vin | neelam      | test          |                   |                  | 0                    | //vcu.my_car_vin/neelam//test             |
+      | vcu.my_car_vin | neelam      | test          | front             |                  | 1                    | //vcu.my_car_vin/neelam/1/test.front      |
+      | vcu.my_car_vin | neelam      | test          | front             |                  | 0                    | //vcu.my_car_vin/neelam//test.front       |
+      | vcu.my_car_vin | neelam      | test          | front             | Test             | 1                    | //vcu.my_car_vin/neelam/1/test.front#Test |
+      | vcu.my_car_vin | neelam      | test          | front             | Test             | 0                    | //vcu.my_car_vin/neelam//test.front#Test  |
+      | vcu.my_car_vin | petapp      | rpc           | response          |                  | 0                    | //vcu.my_car_vin/petapp//rpc.response     |

--- a/test_manager/features/tests/serializers/long_uuid_serializer.feature
+++ b/test_manager/features/tests/serializers/long_uuid_serializer.feature
@@ -26,7 +26,7 @@
 Feature: UUID serialization
 
   Scenario Outline: Testing uuid serializer
-    Given "<uE1>" creates data for "uuid_serialize"
+    Given "uE1" creates data for "uuid_serialize"
     And sets "lsb" to "<lsb>"
     And sets "msb" to "<msb>"
 
@@ -34,6 +34,5 @@ Feature: UUID serialization
     Then the serialized uuid received is "<expected_uuid>"
 
     Examples:
-      | uE1    | lsb                  | msb                | expected_uuid                        |
-      | python | 11155833020022798372 | 112128268635242497 | 018e5c10-f548-8001-9ad1-7b068c083824 |
-      | java   | 11155833020022798372 | 112128268635242497 | 018e5c10-f548-8001-9ad1-7b068c083824 |
+      | lsb                  | msb                | expected_uuid                        |
+      | 11155833020022798372 | 112128268635242497 | 018e5c10-f548-8001-9ad1-7b068c083824 |

--- a/test_manager/features/tests/validators/uri_validator.feature
+++ b/test_manager/features/tests/validators/uri_validator.feature
@@ -27,7 +27,7 @@
 Feature: URI Validation
 
   Scenario Outline: Validate different types of URIs
-    Given "<uE1>" creates data for "uri_validate"
+    Given "uE1" creates data for "uri_validate"
       And sets "uri" to "<uri>"
       And sets "type" to "<validation_type>"
 
@@ -36,158 +36,81 @@ Feature: URI Validation
       And  receives validation message as "<expected_message>"
 
     Examples:
-        | uE1    | uri                                                 | validation_type          | expected_status| expected_message             | 
-        | python |                                                     | uri                      | False          | Uri is empty.                |
-        | python | //                                                  | uri                      | False          | Uri is empty.                |
-        | python | /neelam                                             | uri                      | True           | none                         |
-        | python | neelam                                              | uri                      | False          | Uri is empty.                |
-        | python | /neelam//rpc.echo                                   | rpc_method               | True           | none                         |
-        | python | /neelam/echo                                        | rpc_method               | False          | Uri is empty.                |
-        | python | neelam                                              | rpc_method               | False          | Uri is empty.                |
-        | python | /neelam//rpc.response                               | rpc_response             | True           | none                         |
-        | python | neelam                                              | rpc_response             | False          | Uri is empty.                |
-        | python | /neelam//dummy.wrong                                | rpc_response             | False          | Invalid RPC response type.   |
-        | python | //VCU.MY_CAR_VIN/body.access/1/door.front_left#Door | uri                      | True           | none                         |
-        | python | //VCU.MY_CAR_VIN/body.access//door.front_left#Door  | uri                      | True           | none                         |
-        | python | /body.access/1/door.front_left#Door                 | uri                      | True           | none                         |
-        | python | /body.access//door.front_left#Door                  | uri                      | True           | none                         |
-        | python | :                                                   | uri                      | False          | none                         |
-        | python | /                                                   | uri                      | False          | none                         |
-        | python | //                                                  | uri                      | False          | none                         |
-        | python | ///body.access/1/door.front_left#Door               | uri                      | False          | none                         |
-        | python | //VCU.myvin///door.front_left#Door                  | uri                      | False          | none                         |
-        | python | /1/door.front_left#Door                             | uri                      | False          | none                         |
-        | python | //VCU.myvin//1                                      | uri                      | False          | none                         |
-        | python | //bo.cloud/petapp/1/rpc.response                    | rpc_method               | True           | none                         |
-        | python | //bo.cloud/petapp//rpc.response                     | rpc_method               | True           | none                         |
-        | python | /petapp/1/rpc.response                              | rpc_method               | True           | none                         |
-        | python | /petapp//rpc.response                               | rpc_method               | True           | none                         |
-        | python | :                                                   | rpc_method               | False          | none                         |
-        | python | /petapp/1/dog                                       | rpc_method               | False          | none                         |
-        | python | //petapp/1/dog                                      | rpc_method               | False          | none                         |
-        | python | //                                                  | rpc_method               | False          | none                         |
-        | python | ///body.access/1                                    | rpc_method               | False          | none                         |
-        | python | //VCU.myvin                                         | rpc_method               | False          | none                         |
-        | python | /1                                                  | rpc_method               | False          | none                         |
-        | python | //VCU.myvin//1                                      | rpc_method               | False          | none                         |
-        | python | //VCU.myvin/body.access/1/rpc.UpdateDoor            | rpc_method               | True           | none                         |
-        | python | //VCU.myvin/body.access//rpc.UpdateDoor             | rpc_method               | True           | none                         |
-        | python | /body.access/1/rpc.UpdateDoor                       | rpc_method               | True           | none                         |
-        | python | /body.access//rpc.UpdateDoor                        | rpc_method               | True           | none                         |
-        | python | ///body.access/1/rpc.UpdateDoor                     | rpc_method               | False          | none                         |
-        | python | /1/rpc.UpdateDoor                                   | rpc_method               | False          | none                         |
-        | python | //VCU.myvin//1/rpc.UpdateDoor                       | rpc_method               | False          | none                         |
-        | python | /hartley                                            | uri                      | True           | none                         |
-        | python | /hartley//                                          | uri                      | True           | none                         |
-        | python | /hartley/0                                          | uri                      | True           | none                         |
-        | python | /1                                                  | uri                      | True           | none                         |
-        | python | /body.access/1                                      | uri                      | True           | none                         |
-        | python | /body.access/1/door.front_left#Door                 | uri                      | True           | none                         |
-        | python | //vcu.vin/body.access/1/door.front_left#Door        | uri                      | True           | none                         |
-        | python | /body.access/1/rpc.OpenWindow                       | uri                      | True           | none                         |
-        | python | /body.access/1/rpc.response                         | uri                      | True           | none                         |
-        | python |                                                     | uri                      | False          | Uri is empty.                |
-        | python | :                                                   | uri                      | False          | Uri is empty.                |
-        | python | ///                                                 | uri                      | False          | Uri is empty.                |
-        | python | ////                                                | uri                      | False          | Uri is empty.                |
-        | python | 1                                                   | uri                      | False          | Uri is empty.                |
-        | python | a                                                   | uri                      | False          | Uri is empty.                |
-        | python | /petapp/1/rpc.OpenWindow                            | rpc_method               | True           | none                         |
-        | python | /petapp/1/rpc.response                              | rpc_method               | True           | none                         |
-        | python | /petapp/1/rpc.response                              | rpc_response             | True           | none                         |
-        | python | /petapp/1/rpc.OpenWindow                            | rpc_response             | False          | none                         |
-        | python | /petapp//                                           | rpc_method               | False          | none                         |
-        | python | /petapp                                             | rpc_method               | False          | none                         |
-        | python | /petapp/1/                                          | rpc_method               | False          | none                         |
-        | python | /petapp/1/rpc                                       | rpc_method               | False          | none                         |
-        | python | /petapp/1/dummy                                     | rpc_method               | False          | none                         |
-        | python | /petapp/1/rpc_dummy                                 | rpc_method               | False          | none                         |
-        | python |                                                     | is_empty                 | True           | none                         |
-        | python | /hartley/23/rpc.echo                                | is_resolved              | False          | none                         |
-        | python |                                                     | is_micro_form            | False          | none                         |
-        | python | /hartley/23/                                        | is_micro_form            | False          | none                         |
-        | python |                                                     | is_long_form_uuri        | False          | none                         |
-        | python |                                                     | is_long_form_uauthority  | False          | none                         |
-        | python | /hartley/23/                                        | is_long_form_uuri        | False          | none                         |
-        | python | //vcu.veh.gm.com/hartley/23/                        | is_long_form_uuri        | False          | none                         |
-        | python | ///hartley/23/                                      | is_long_form_uuri        | False          | none                         |
-        | python | ///hartley/23/                                      | is_long_form_uauthority  | False          | none                         |
-        | python |                                                     | is_micro_form            | False          | none                         |
-        | python | ///hartley/23/                                      | is_micro_form            | False          | none                         |
-        | java   |                                                     | uri                      | False          | Uri is empty.                |
-        | java   | //                                                  | uri                      | False          | Uri is empty.                |
-        | java   | /neelam                                             | uri                      | True           | none                         |
-        | java   | neelam                                              | uri                      | False          | Uri is empty.                |
-        | java   | /neelam//rpc.echo                                   | rpc_method               | True           | none                         |
-        | java   | /neelam/echo                                        | rpc_method               | False          | Uri is empty.                |
-        | java   | neelam                                              | rpc_method               | False          | Uri is empty.                |
-        | java   | /neelam//rpc.response                               | rpc_response             | True           | none                         |
-        | java   | neelam                                              | rpc_response             | False          | Uri is empty.                |
-        | java   | /neelam//dummy.wrong                                | rpc_response             | False          | Invalid RPC response type.   |
-        | java   | //VCU.MY_CAR_VIN/body.access/1/door.front_left#Door | uri                      | True           | none                         |
-        | java   | //VCU.MY_CAR_VIN/body.access//door.front_left#Door  | uri                      | True           | none                         |
-        | java   | /body.access/1/door.front_left#Door                 | uri                      | True           | none                         |
-        | java   | /body.access//door.front_left#Door                  | uri                      | True           | none                         |
-        | java   | :                                                   | uri                      | False          | none                         |
-        | java   | /                                                   | uri                      | False          | none                         |
-        | java   | //                                                  | uri                      | False          | none                         |
-        | java   | ///body.access/1/door.front_left#Door               | uri                      | False          | none                         |
-        | java   | //VCU.myvin///door.front_left#Door                  | uri                      | False          | none                         |
-        | java   | /1/door.front_left#Door                             | uri                      | False          | none                         |
-        | java   | //VCU.myvin//1                                      | uri                      | False          | none                         |
-        | java   | //bo.cloud/petapp/1/rpc.response                    | rpc_method               | True           | none                         |
-        | java   | //bo.cloud/petapp//rpc.response                     | rpc_method               | True           | none                         |
-        | java   | /petapp/1/rpc.response                              | rpc_method               | True           | none                         |
-        | java   | /petapp//rpc.response                               | rpc_method               | True           | none                         |
-        | java   | :                                                   | rpc_method               | False          | none                         |
-        | java   | /petapp/1/dog                                       | rpc_method               | False          | none                         |
-        | java   | //petapp/1/dog                                      | rpc_method               | False          | none                         |
-        | java   | //                                                  | rpc_method               | False          | none                         |
-        | java   | ///body.access/1                                    | rpc_method               | False          | none                         |
-        | java   | //VCU.myvin                                         | rpc_method               | False          | none                         |
-        | java   | /1                                                  | rpc_method               | False          | none                         |
-        | java   | //VCU.myvin//1                                      | rpc_method               | False          | none                         |
-        | java   | //VCU.myvin/body.access/1/rpc.UpdateDoor            | rpc_method               | True           | none                         |
-        | java   | //VCU.myvin/body.access//rpc.UpdateDoor             | rpc_method               | True           | none                         |
-        | java   | /body.access/1/rpc.UpdateDoor                       | rpc_method               | True           | none                         |
-        | java   | /body.access//rpc.UpdateDoor                        | rpc_method               | True           | none                         |
-        | java   | ///body.access/1/rpc.UpdateDoor                     | rpc_method               | False          | none                         |
-        | java   | /1/rpc.UpdateDoor                                   | rpc_method               | False          | none                         |
-        | java   | //VCU.myvin//1/rpc.UpdateDoor                       | rpc_method               | False          | none                         |
-        | java   | /hartley                                            | uri                      | True           | none                         |
-        | java   | /hartley//                                          | uri                      | True           | none                         |
-        | java   | /hartley/0                                          | uri                      | True           | none                         |
-        | java   | /1                                                  | uri                      | True           | none                         |
-        | java   | /body.access/1                                      | uri                      | True           | none                         |
-        | java   | /body.access/1/door.front_left#Door                 | uri                      | True           | none                         |
-        | java   | //vcu.vin/body.access/1/door.front_left#Door        | uri                      | True           | none                         |
-        | java   | /body.access/1/rpc.OpenWindow                       | uri                      | True           | none                         |
-        | java   | /body.access/1/rpc.response                         | uri                      | True           | none                         |
-        | java   |                                                     | uri                      | False          | Uri is empty.                |
-        | java   | :                                                   | uri                      | False          | Uri is empty.                |
-        | java   | ///                                                 | uri                      | False          | Uri is empty.                |
-        | java   | ////                                                | uri                      | False          | Uri is empty.                |
-        | java   | 1                                                   | uri                      | False          | Uri is empty.                |
-        | java   | a                                                   | uri                      | False          | Uri is empty.                |
-        | java   | /petapp/1/rpc.OpenWindow                            | rpc_method               | True           | none                         |
-        | java   | /petapp/1/rpc.response                              | rpc_method               | True           | none                         |
-        | java   | /petapp/1/rpc.response                              | rpc_response             | True           | none                         |
-        | java   | /petapp/1/rpc.OpenWindow                            | rpc_response             | False          | none                         |
-        | java   | /petapp//                                           | rpc_method               | False          | none                         |
-        | java   | /petapp                                             | rpc_method               | False          | none                         |
-        | java   | /petapp/1/                                          | rpc_method               | False          | none                         |
-        | java   | /petapp/1/rpc                                       | rpc_method               | False          | none                         |
-        | java   | /petapp/1/dummy                                     | rpc_method               | False          | none                         |
-        | java   | /petapp/1/rpc_dummy                                 | rpc_method               | False          | none                         |
-        | java   |                                                     | is_empty                 | True           | none                         |
-        | java   | /hartley/23/rpc.echo                                | is_resolved              | False          | none                         |
-        | java   |                                                     | is_micro_form            | False          | none                         |
-        | java   | /hartley/23/                                        | is_micro_form            | False          | none                         |
-        | java   |                                                     | is_long_form_uuri        | False          | none                         |
-        | java   |                                                     | is_long_form_uauthority  | False          | none                         |
-        | java   | /hartley/23/                                        | is_long_form_uuri        | False          | none                         |
-        | java   | //vcu.veh.gm.com/hartley/23/                        | is_long_form_uuri        | False          | none                         |
-        | java   | ///hartley/23/                                      | is_long_form_uuri        | False          | none                         |
-        | java   | ///hartley/23/                                      | is_long_form_uauthority  | False          | none                         |
-        | java   |                                                     | is_micro_form            | False          | none                         |
-        | java   | ///hartley/23/                                      | is_micro_form            | False          | none                         |
+        | uri                                                 | validation_type          | expected_status| expected_message             | 
+        |                                                     | uri                      | False          | Uri is empty.                |
+        | //                                                  | uri                      | False          | Uri is empty.                |
+        | /neelam                                             | uri                      | True           | none                         |
+        | neelam                                              | uri                      | False          | Uri is empty.                |
+        | /neelam//rpc.echo                                   | rpc_method               | True           | none                         |
+        | /neelam/echo                                        | rpc_method               | False          | Uri is empty.                |
+        | neelam                                              | rpc_method               | False          | Uri is empty.                |
+        | /neelam//rpc.response                               | rpc_response             | True           | none                         |
+        | neelam                                              | rpc_response             | False          | Uri is empty.                |
+        | /neelam//dummy.wrong                                | rpc_response             | False          | Invalid RPC response type.   |
+        | //VCU.MY_CAR_VIN/body.access/1/door.front_left#Door | uri                      | True           | none                         |
+        | //VCU.MY_CAR_VIN/body.access//door.front_left#Door  | uri                      | True           | none                         |
+        | /body.access/1/door.front_left#Door                 | uri                      | True           | none                         |
+        | /body.access//door.front_left#Door                  | uri                      | True           | none                         |
+        | :                                                   | uri                      | False          | none                         |
+        | /                                                   | uri                      | False          | none                         |
+        | //                                                  | uri                      | False          | none                         |
+        | ///body.access/1/door.front_left#Door               | uri                      | False          | none                         |
+        | //VCU.myvin///door.front_left#Door                  | uri                      | False          | none                         |
+        | /1/door.front_left#Door                             | uri                      | False          | none                         |
+        | //VCU.myvin//1                                      | uri                      | False          | none                         |
+        | //bo.cloud/petapp/1/rpc.response                    | rpc_method               | True           | none                         |
+        | //bo.cloud/petapp//rpc.response                     | rpc_method               | True           | none                         |
+        | /petapp/1/rpc.response                              | rpc_method               | True           | none                         |
+        | /petapp//rpc.response                               | rpc_method               | True           | none                         |
+        | :                                                   | rpc_method               | False          | none                         |
+        | /petapp/1/dog                                       | rpc_method               | False          | none                         |
+        | //petapp/1/dog                                      | rpc_method               | False          | none                         |
+        | //                                                  | rpc_method               | False          | none                         |
+        | ///body.access/1                                    | rpc_method               | False          | none                         |
+        | //VCU.myvin                                         | rpc_method               | False          | none                         |
+        | /1                                                  | rpc_method               | False          | none                         |
+        | //VCU.myvin//1                                      | rpc_method               | False          | none                         |
+        | //VCU.myvin/body.access/1/rpc.UpdateDoor            | rpc_method               | True           | none                         |
+        | //VCU.myvin/body.access//rpc.UpdateDoor             | rpc_method               | True           | none                         |
+        | /body.access/1/rpc.UpdateDoor                       | rpc_method               | True           | none                         |
+        | /body.access//rpc.UpdateDoor                        | rpc_method               | True           | none                         |
+        | ///body.access/1/rpc.UpdateDoor                     | rpc_method               | False          | none                         |
+        | /1/rpc.UpdateDoor                                   | rpc_method               | False          | none                         |
+        | //VCU.myvin//1/rpc.UpdateDoor                       | rpc_method               | False          | none                         |
+        | /hartley                                            | uri                      | True           | none                         |
+        | /hartley//                                          | uri                      | True           | none                         |
+        | /hartley/0                                          | uri                      | True           | none                         |
+        | /1                                                  | uri                      | True           | none                         |
+        | /body.access/1                                      | uri                      | True           | none                         |
+        | /body.access/1/door.front_left#Door                 | uri                      | True           | none                         |
+        | //vcu.vin/body.access/1/door.front_left#Door        | uri                      | True           | none                         |
+        | /body.access/1/rpc.OpenWindow                       | uri                      | True           | none                         |
+        | /body.access/1/rpc.response                         | uri                      | True           | none                         |
+        |                                                     | uri                      | False          | Uri is empty.                |
+        | :                                                   | uri                      | False          | Uri is empty.                |
+        | ///                                                 | uri                      | False          | Uri is empty.                |
+        | ////                                                | uri                      | False          | Uri is empty.                |
+        | 1                                                   | uri                      | False          | Uri is empty.                |
+        | a                                                   | uri                      | False          | Uri is empty.                |
+        | /petapp/1/rpc.OpenWindow                            | rpc_method               | True           | none                         |
+        | /petapp/1/rpc.response                              | rpc_method               | True           | none                         |
+        | /petapp/1/rpc.response                              | rpc_response             | True           | none                         |
+        | /petapp/1/rpc.OpenWindow                            | rpc_response             | False          | none                         |
+        | /petapp//                                           | rpc_method               | False          | none                         |
+        | /petapp                                             | rpc_method               | False          | none                         |
+        | /petapp/1/                                          | rpc_method               | False          | none                         |
+        | /petapp/1/rpc                                       | rpc_method               | False          | none                         |
+        | /petapp/1/dummy                                     | rpc_method               | False          | none                         |
+        | /petapp/1/rpc_dummy                                 | rpc_method               | False          | none                         |
+        |                                                     | is_empty                 | True           | none                         |
+        | /hartley/23/rpc.echo                                | is_resolved              | False          | none                         |
+        |                                                     | is_micro_form            | False          | none                         |
+        | /hartley/23/                                        | is_micro_form            | False          | none                         |
+        |                                                     | is_long_form_uuri        | False          | none                         |
+        |                                                     | is_long_form_uauthority  | False          | none                         |
+        | /hartley/23/                                        | is_long_form_uuri        | False          | none                         |
+        | //vcu.veh.gm.com/hartley/23/                        | is_long_form_uuri        | False          | none                         |
+        | ///hartley/23/                                      | is_long_form_uuri        | False          | none                         |
+        | ///hartley/23/                                      | is_long_form_uauthority  | False          | none                         |
+        |                                                     | is_micro_form            | False          | none                         |
+        | ///hartley/23/                                      | is_micro_form            | False          | none                         |

--- a/test_manager/testrunner.bat
+++ b/test_manager/testrunner.bat
@@ -1,6 +1,7 @@
 @echo off
 
 set /p fname=Enter the feature file name:
+  set /p language=Enter Language Under Test [python/java]:
 
     REM Run Behave with HTML formatter
-    python -m behave -i %fname% --format html --outfile reports/%fname%_%date:~10,4%%date:~4,2%%date:~7,2%_%RANDOM%.html
+    python -m behave --define uE1=%language% -i %fname% --format html --outfile reports/%fname%_%date:~10,4%%date:~4,2%%date:~7,2%_%RANDOM%.html

--- a/test_manager/testrunner.sh
+++ b/test_manager/testrunner.sh
@@ -1,3 +1,5 @@
 echo Enter the feature file name
 read fname
-python3 -m behave -i "${fname}" --format html --outfile reports/"${fname}_$(date +%Y%m%d_%H%M%S).html"
+echo Enter Language Under Test [python/java]
+read language
+python3 -m behave --define uE1=%language% -i "${fname}" --format html --outfile reports/"${fname}_$(date +%Y%m%d_%H%M%S).html"


### PR DESCRIPTION
* Remove references to "java" and "python" in feature files where relevant.
* Add "uE1" variable to testrunner scripts to allow users to specify language under test.
* Make outputted reports in Github Actions more specific to the language under test.