### PR TITLE
Generalize process spawning

### DIFF
--- a/.github/workflows/tck-test.yml
+++ b/.github/workflows/tck-test.yml
@@ -86,8 +86,8 @@ jobs:
             
             # Run behave command
             echo "Running Test: $filename"
-            behave --define uE1=python --format json --outfile "./reports/${filename}_python.json" --format html --outfile "./reports/${filename}_python.html" "$full_path"
-            behave --define uE1=java --format json --outfile "./reports/${filename}_java.json" --format html --outfile "./reports/${filename}_java.html" "$full_path"
+            behave --define uE1=python --define transport=socket --format json --outfile "./reports/${filename}_python.json" --format html --outfile "./reports/${filename}_python.html" "$full_path"
+            behave --define uE1=java --define transport=socket --format json --outfile "./reports/${filename}_java.json" --format html --outfile "./reports/${filename}_java.html" "$full_path"
             echo "Finished Test: $filename"
         done
     - name: Get Behave Scripts

--- a/test_manager/features/environment.py
+++ b/test_manager/features/environment.py
@@ -24,12 +24,9 @@
 #
 # -------------------------------------------------------------------------
 
-import os
 import subprocess
 import sys
-import time
 from threading import Thread
-from typing import List
 
 import git
 from behave.runner import Context
@@ -38,54 +35,7 @@ repo = git.Repo(".", search_parent_directories=True)
 sys.path.insert(0, repo.working_tree_dir)
 
 from test_manager.testmanager import TestManager
-from dispatcher.dispatcher import Dispatcher
 from test_manager.features.utils import loggerutils
-
-PYTHON_TA_PATH = "/test_agent/python/testagent.py"
-JAVA_TA_PATH = (
-    "/test_agent/java/target/tck-test-agent-java-jar-with-dependencies.jar"
-)
-DISPATCHER_PATH = "/dispatcher/dispatcher.py"
-
-
-def create_command(filepath_from_root_repo: str) -> List[str]:
-    command: List[str] = []
-
-    if filepath_from_root_repo.endswith(".jar"):
-        command.append("java")
-        command.append("-jar")
-    elif filepath_from_root_repo.endswith(".py"):
-        if sys.platform == "win32":
-            command.append("python")
-        elif (
-            sys.platform == "linux"
-            or sys.platform == "linux2"
-            or sys.platform == "darwin"
-        ):
-            command.append("python3")
-    else:
-        raise Exception("only accept .jar and .py files")
-    command.append(
-        os.path.abspath(
-            os.path.dirname(os.getcwd()) + "/" + filepath_from_root_repo
-        )
-    )
-    return command
-
-
-def create_subprocess(command: List[str]) -> subprocess.Popen:
-    if sys.platform == "win32":
-        process = subprocess.Popen(command, shell=True)
-    elif (
-        sys.platform == "linux"
-        or sys.platform == "linux2"
-        or sys.platform == "darwin"
-    ):
-        process = subprocess.Popen(command)
-    else:
-        print(sys.platform)
-        raise Exception("only handle Windows and Linux commands for now")
-    return process
 
 
 def before_all(context):
@@ -98,18 +48,12 @@ def before_all(context):
     :return: None
     """
 
+    context.transport = {}
+    context.ues = {}
+    context.dispatcher = {}
+
     loggerutils.setup_logging()
     loggerutils.setup_formatted_logging(context)
-
-    context.logger.info("Creating Dispatcher...")
-
-    dispatcher = Dispatcher()
-    thread = Thread(target=dispatcher.listen_for_client_connections)
-    thread.start()
-    context.dispatcher = dispatcher
-
-    context.logger.info("Created Dispatcher...")
-    time.sleep(5)
 
     test_manager = TestManager(context, "127.0.0.5", 12345)
     thread = Thread(target=test_manager.listen_for_incoming_events)
@@ -117,16 +61,6 @@ def before_all(context):
     context.tm = test_manager
 
     context.logger.info("Created Test Manager...")
-
-    command = create_command(PYTHON_TA_PATH)
-    process: subprocess.Popen = create_subprocess(command)
-    context.python_ta_process = process
-
-    command = create_command(JAVA_TA_PATH)
-    process: subprocess.Popen = create_subprocess(command)
-    context.java_ta_process = process
-
-    context.logger.info("Created All Test Agents...")
 
 
 def after_all(context: Context):
@@ -137,12 +71,12 @@ def after_all(context: Context):
     context.tm.close_test_agent("python")
     context.tm.close_test_agent("java")
     context.tm.close()
-    context.dispatcher.close()
+    context.dispatcher["socket"].close()
 
     context.logger.info("Closed All Test Agents and Test Manager...")
-
     try:
-        context.java_ta_process.terminate()
-        context.python_ta_process.terminate()
+        for ue in context.ues:
+            for process in context.ues[ue]:
+                process.terminate()
     except Exception as e:
         context.logger.error(e)

--- a/test_manager/features/steps/tck_step_implementations.py
+++ b/test_manager/features/steps/tck_step_implementations.py
@@ -25,12 +25,70 @@
 # -------------------------------------------------------------------------
 import base64
 import codecs
+import time
+import sys
+import os
+import subprocess
 from typing import Any, Dict
 from uprotocol.proto.ustatus_pb2 import UCode
+from threading import Thread
+from typing import List
 
 from behave import when, then, given
 from behave.runner import Context
 from hamcrest import assert_that, equal_to
+import git
+
+PYTHON_TA_PATH = "/test_agent/python/testagent.py"
+JAVA_TA_PATH = (
+    "/test_agent/java/target/tck-test-agent-java-jar-with-dependencies.jar"
+)
+DISPATCHER_PATH = "/dispatcher/dispatcher.py"
+
+repo = git.Repo(".", search_parent_directories=True)
+sys.path.insert(0, repo.working_tree_dir)
+
+from dispatcher.dispatcher import Dispatcher
+
+
+def create_command(filepath_from_root_repo: str) -> List[str]:
+    command: List[str] = []
+
+    if filepath_from_root_repo.endswith(".jar"):
+        command.append("java")
+        command.append("-jar")
+    elif filepath_from_root_repo.endswith(".py"):
+        if sys.platform == "win32":
+            command.append("python")
+        elif (
+            sys.platform == "linux"
+            or sys.platform == "linux2"
+            or sys.platform == "darwin"
+        ):
+            command.append("python3")
+    else:
+        raise Exception("only accept .jar and .py files")
+    command.append(
+        os.path.abspath(
+            os.path.dirname(os.getcwd()) + "/" + filepath_from_root_repo
+        )
+    )
+    return command
+
+
+def create_subprocess(command: List[str]) -> subprocess.Popen:
+    if sys.platform == "win32":
+        process = subprocess.Popen(command, shell=True)
+    elif (
+        sys.platform == "linux"
+        or sys.platform == "linux2"
+        or sys.platform == "darwin"
+    ):
+        process = subprocess.Popen(command)
+    else:
+        print(sys.platform)
+        raise Exception("only handle Windows and Linux commands for now")
+    return process
 
 
 @given('"{sdk_name}" creates data for "{command}"')
@@ -39,7 +97,27 @@ def create_sdk_data(context, sdk_name: str, command: str):
     context.json_dict = {}
     context.status_json = None
     if sdk_name == "uE1":
-        sdk_name = context.config.userdata['uE1']
+        sdk_name = context.config.userdata["uE1"]
+
+    if context.transport == {}:
+        context.transport["transport"] = context.config.userdata["transport"]
+        if context.transport["transport"] == "socket":
+            dispatcher = Dispatcher()
+            thread = Thread(target=dispatcher.listen_for_client_connections)
+            thread.start()
+            context.dispatcher[context.transport["transport"]] = dispatcher
+            time.sleep(5)
+        else:
+            raise ValueError("Invalid transport")
+
+    if sdk_name not in context.ues:
+        context.logger.info(f"Creating {sdk_name} process...")
+        run_command = create_command(PYTHON_TA_PATH if sdk_name == "python" else JAVA_TA_PATH)
+        process = create_subprocess(run_command)
+        if sdk_name in ["python", "java"]:
+            context.ues.setdefault(sdk_name, []).append(process)
+        else:
+            raise ValueError("Invalid SDK name")
 
     while not context.tm.has_sdk_connection(sdk_name):
         continue
@@ -362,6 +440,7 @@ def send_micro_serialized_command(
 
     context.logger.info(f"Response Json {command} -> {response_json}")
     context.response_data = response_json["data"]
+
 
 def access_nested_dict(dictionary, keys):
     keys = keys.split(".")

--- a/test_manager/testrunner.bat
+++ b/test_manager/testrunner.bat
@@ -2,6 +2,7 @@
 
 set /p fname=Enter the feature file name:
   set /p language=Enter Language Under Test [python/java]:
+    set /p transport=Enter Transport Under Test [socket]:
 
     REM Run Behave with HTML formatter
-    python -m behave --define uE1=%language% -i %fname% --format html --outfile reports/%fname%_%date:~10,4%%date:~4,2%%date:~7,2%_%RANDOM%.html
+    python -m behave --define uE1=%language% --define transport=%transport% -i %fname% --format html --outfile reports/%fname%_%date:~10,4%%date:~4,2%%date:~7,2%_%RANDOM%.html

--- a/test_manager/testrunner.sh
+++ b/test_manager/testrunner.sh
@@ -2,4 +2,5 @@ echo Enter the feature file name
 read fname
 echo Enter Language Under Test [python/java]
 read language
-python3 -m behave --define uE1=%language% -i "${fname}" --format html --outfile reports/"${fname}_$(date +%Y%m%d_%H%M%S).html"
+echo Enter Transport Under Test [socket]
+python3 -m behave --define uE1=%language% --define transport=%socket% -i "${fname}" --format html --outfile reports/"${fname}_$(date +%Y%m%d_%H%M%S).html"

--- a/test_manager/testrunner.sh
+++ b/test_manager/testrunner.sh
@@ -3,4 +3,5 @@ read fname
 echo Enter Language Under Test [python/java]
 read language
 echo Enter Transport Under Test [socket]
-python3 -m behave --define uE1=%language% --define transport=%socket% -i "${fname}" --format html --outfile reports/"${fname}_$(date +%Y%m%d_%H%M%S).html"
+read transport
+python3 -m behave --define uE1=%language% --define transport=%transport% -i "${fname}" --format html --outfile reports/"${fname}_$(date +%Y%m%d_%H%M%S).html"

--- a/test_manager/testrunner.sh
+++ b/test_manager/testrunner.sh
@@ -4,4 +4,4 @@ echo Enter Language Under Test [python/java]
 read language
 echo Enter Transport Under Test [socket]
 read transport
-python3 -m behave --define uE1=%language% --define transport=%transport% -i "${fname}" --format html --outfile reports/"${fname}_$(date +%Y%m%d_%H%M%S).html"
+python3 -m behave --define uE1="${language}" --define transport="${transport}" -i "${fname}" --format html --outfile reports/"${fname}_$(date +%Y%m%d_%H%M%S).html"


### PR DESCRIPTION
In the original implementation of these tests, every test agent was spawned no matter the test. This was inefficient and difficult when running tests locally. 

This PR addresses that issue by spawning Test Agents dynamically in the step implementation themselves. In this way, only Test Agents that are referenced are spawned.